### PR TITLE
Fix error in running example inference for add_sub_notebook

### DIFF
--- a/examples/add_sub_notebook/add_sub.ipynb
+++ b/examples/add_sub_notebook/add_sub.ipynb
@@ -60,6 +60,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
+    "from pytriton.decorators import batch\n",
     "from pytriton.model_config import ModelConfig, Tensor\n",
     "from pytriton.triton import Triton"
    ]
@@ -77,6 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "@batch\n",
     "def _add_sub(**inputs):\n",
     "    a_batch, b_batch = inputs.values()\n",
     "    add_batch = a_batch + b_batch\n",
@@ -205,6 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "@batch\n",
     "def _add_sub(**inputs):\n",
     "    a_batch, b_batch = inputs.values()\n",
     "    add_batch = (a_batch + b_batch) * 2\n",


### PR DESCRIPTION
When I follow the `add_sub_notebook` to try PyTriton, I meet this error in the following cell:

```python
with ModelClient("localhost", "AddSub") as client:
    result_batch = client.infer_batch(a_batch, b_batch)

for output_name, data_batch in result_batch.items():
    print(f"{output_name}: {data_batch.tolist()}")
```

The error logs can be found below:

```
Error occurred during calling model callable: Traceback (most recent call last):
  File "/home/xiaodongye/miniconda3/envs/pytorch_source/lib/python3.8/site-packages/pytriton/proxy/inference_handler.py", line 117, in run
    outputs = self._model_callable(inputs)
TypeError: _add_sub() takes 0 positional arguments but 1 was given
```

After adding `@batch` to `_add_sub`, the issue is gone.