### PR TITLE
Update megatron example so that it would support latest changes in NeMo

### DIFF
--- a/examples/nemo_megatron_gpt_multinode/client.py
+++ b/examples/nemo_megatron_gpt_multinode/client.py
@@ -86,7 +86,11 @@ def main():
         action="store_true",
         help="Enable verbose logging",
     )
-
+    parser.add_argument(
+        "--end-strings",
+        nargs="+",
+        default=["\n"],
+    )
     args = parser.parse_args()
 
     log_level = logging.DEBUG if args.verbose else logging.INFO
@@ -122,7 +126,7 @@ def main():
         result_dict = client.infer_batch(
             tasks=tasks,
             prompts=prompts,
-            min_length=_param(np.int32, 0),
+            min_length=_param(np.int32, 20),
             max_length=_param(np.int32, args.output_len),
             use_greedy=_param(np.bool_, True),
             temperature=_param(np.float32, 1.0),
@@ -132,6 +136,7 @@ def main():
             add_BOS=_param(np.bool_, True),
             all_probs=_param(np.bool_, False),
             compute_logprob=_param(np.bool_, False),
+            end_strings=np.tile(_str_list2numpy(args.end_strings), (batch_size, 1)),
         )
 
     sentences = np.char.decode(result_dict["sentences"].astype("bytes"), "utf-8")

--- a/examples/nemo_megatron_gpt_multinode/client.py
+++ b/examples/nemo_megatron_gpt_multinode/client.py
@@ -136,7 +136,8 @@ def main():
             add_BOS=_param(np.bool_, True),
             all_probs=_param(np.bool_, False),
             compute_logprob=_param(np.bool_, False),
-            end_strings=np.tile(_str_list2numpy(args.end_strings), (batch_size, 1)),
+            end_strings=np.tile(np.char.encode(np.array(args.end_strings)[np.newaxis, np.newaxis, ...], "utf-8"), (batch_size, 1, 1)),
+            #end_strings=np.tile(np.char.encode(np.array(args.end_strings)[np.newaxis, ...], "utf-8"), (batch_size, 1)),
         )
 
     sentences = np.char.decode(result_dict["sentences"].astype("bytes"), "utf-8")

--- a/examples/nemo_megatron_gpt_multinode/gpt.py
+++ b/examples/nemo_megatron_gpt_multinode/gpt.py
@@ -82,12 +82,13 @@ class NemoGptCallable:
 
         tasks = _str_ndarray2list(inputs.pop("tasks"))
         prompts = _str_ndarray2list(inputs.pop("prompts"))
-
         length_params = LengthParam(**{k: v for k, v in inputs.items() if k in typing.get_type_hints(LengthParam)})
+        end_strings = inputs.pop("end_strings")
+        end_strings = [end_strings.decode(encoding="utf-8")]
         sampling_params = SamplingParam(
             **{k: v for k, v in inputs.items() if k in typing.get_type_hints(SamplingParam)}
         )
-
+        sampling_params["end_strings"] = end_strings
         if tasks[0] == "text_generation":
             generate_fn = self._text_generate_fn
         else:

--- a/examples/nemo_megatron_gpt_multinode/helpers.py
+++ b/examples/nemo_megatron_gpt_multinode/helpers.py
@@ -82,8 +82,8 @@ def typedict2tensor(
         while typing.get_origin(type_) is list:
             type_ = typing.get_args(type_)[0]
             count += 1
-        count -= 1  # we don't want to count the last dimension
-        shape = (-1,) * count if count > 0 else (1,)
+        # count -= 1  # we don't want to count the last dimension
+        shape = (1,) + (-1,) * count if count > 0 else (1,)
         return {"shape": shape, "dtype": _map_type(type_)}
 
     overwrite_kwargs = overwrite_kwargs or {}

--- a/examples/nemo_megatron_gpt_multinode/helpers.py
+++ b/examples/nemo_megatron_gpt_multinode/helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import importlib
 import logging
+import os
 import pathlib
 import socket
 import typing
@@ -179,6 +180,8 @@ def load_model(
     LOGGER.debug(f"Loading {model_path} on {worker_name}")
 
     save_restore_connector = NLPSaveRestoreConnector()
+    if os.path.isdir(model_path):
+        save_restore_connector.model_extracted_dir = model_path.as_posix()
     pretrained_cfg = save_restore_connector.restore_from(
         None, model_path.as_posix(), return_config=True, trainer=trainer
     )

--- a/examples/nemo_megatron_gpt_multinode/server.py
+++ b/examples/nemo_megatron_gpt_multinode/server.py
@@ -71,6 +71,7 @@ def main():
         "--model-path",
         help="Path to the model nemo file in local file system. This argument has a higher priority "
         "than `--model-repo-id`.",
+        type=Path,
     )
     parser.add_argument("--prompt-model-path", help="Path to the model prompt nemo file")
     parser.add_argument(

--- a/examples/nemo_megatron_gpt_multinode/server.py
+++ b/examples/nemo_megatron_gpt_multinode/server.py
@@ -106,8 +106,14 @@ def main():
         default="GPT",
         help="A name of a Megatron model inside Triton.",
     )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        help="Path to a directory where workspace has to be created (optional)."
+        "If not provided workspace with random name will be created in ~/.cache/pytriton directory."
+    )
     args = parser.parse_args()
-    for arg_name in ["triton_config", "model_path"]:
+    for arg_name in ["triton_config", "model_path", "workspace"]:
         arg_value = getattr(args, arg_name)
         if arg_value is not None:
             setattr(args, arg_name, arg_value.resolve())
@@ -151,7 +157,7 @@ def main():
             triton_config = TritonConfig(http_address=ENDPOINT_BIND_ADDRESS, http_port=HTTP_PORT)
         else:
             triton_config = init_triton_config_from_file(args.yaml_config)
-        with Triton(config=triton_config) as triton:
+        with Triton(config=triton_config, workspace=args.workspace) as triton:
             triton.bind(
                 model_name=infer_callable.model_name,
                 infer_func=infer_callable.infer,

--- a/examples/nemo_megatron_gpt_multinode/server.py
+++ b/examples/nemo_megatron_gpt_multinode/server.py
@@ -46,6 +46,9 @@ DEFAULT_LOG_FORMAT = "%(asctime)s - %(levelname)8s - %(process)8d - %(threadName
 def init_triton_config_from_file(yaml_config: Union[str, os.PathLike]) -> TritonConfig:
     with open(yaml_config) as f:
         data = yaml.safe_load(f)
+    for key in ["model_repository", "log_file", "grpc_server_cert", "grpc_server_key", "grpc_root_cert"]:
+        if key in data:
+            data[key] = Path(data[key])
     return TritonConfig(**data)
 
 

--- a/examples/nemo_megatron_gpt_multinode/server.py
+++ b/examples/nemo_megatron_gpt_multinode/server.py
@@ -156,7 +156,7 @@ def main():
         if args.triton_config is None:
             triton_config = TritonConfig(http_address=ENDPOINT_BIND_ADDRESS, http_port=HTTP_PORT)
         else:
-            triton_config = init_triton_config_from_file(args.yaml_config)
+            triton_config = init_triton_config_from_file(args.triton_config)
         with Triton(config=triton_config, workspace=args.workspace) as triton:
             triton.bind(
                 model_name=infer_callable.model_name,


### PR DESCRIPTION
## What does this PR do?

Modifications done only to Megatron multinode example.

1. Adds `end_strings` parameter
2. Increases default `min_length` to `20`. It is done to avoid empty responses.
3. Add extra dimension to tensor shape if an input is a list (specifically, for `end_strings` case)
4. Add support for unpacked `.nemo` checkpoint
5. Use `NLPDDPStrategy` instead of `NLPDDPPlugin`.
6. Add support for passing `TritonConfig` into NeMo Megatron multinode example
7. Add `--model-name` parameter to NeMo Megatron multinode example
8. Add `--workspace` parameter to NeMo Megatron multinode example
9. Add `--model-path` for loading local checkpoints instead of HuggingFace checkpoints