### PR TITLE
fix: Remove duplicated paragraph

### DIFF
--- a/docs/binding_models.md
+++ b/docs/binding_models.md
@@ -240,12 +240,6 @@ tensor3 = Tensor(name="tensor3", shape=(-1,), dtype="float32"),
 When the model gets into a state where further inference is impossible,
 you can throw [PyTritonUnrecoverableError][pytriton.exceptions.PyTritonUnrecoverableError]
 from the inference callable. This will cause NVIDIA Triton Inference Server to shut down.
-This might be useful when the model is deployed on a cluster in a multi-node setup. In that case
-to recover the model you need to restart all "workers" on the cluster.
-
-When the model gets into a state where further inference is impossible,
-you can throw the [PyTritonUnrecoverableError][pytriton.exceptions.PyTritonUnrecoverableError]
-from the inference callable. This will cause the NVIDIA Triton Inference Server to shut down.
 This might be useful when the model is deployed on a cluster in a multi-node setup. In that case,
 to recover the model, you need to restart all "workers" on the cluster.
 


### PR DESCRIPTION
The same paragraph was repeated in [Binding Models to Triton](https://triton-inference-server.github.io/pytriton/0.5.1/binding_models/).  This PR removes one duplicated paragraph from this page. 

![Screenshot 2024-02-17 at 12 26 06](https://github.com/triton-inference-server/pytriton/assets/18341155/ab46fefc-e4cd-4589-96a2-33117e85bc99)

There are slight differences between the two paragraphs.

- Diff 1
  - (1st Paragraph) you can throw [PyTritonUnrecoverableError] ...
  - (2nd Paragraph) you can throw the [PyTritonUnrecoverableError] ... 
    - "the" is added.
- Diff 2
  - (1st Paragraph) In that case to recover the model ...
    - `,` is missing
  - (2nd Paragraph) In that case, to recover the model, ...

I removed "the" before `PyTritonUnrecoverableError` and added the commas `,` after  "case" and "model".
