### PR TITLE
disallow use of numpy 2 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ keywords = []
 license = { text = "Apache 2.0" }
 requires-python = ">=3.8,<4"
 dependencies = [
-    "numpy >= 1.21",
+    "numpy >= 1.21, <2.0.0",
     "protobuf >= 3.7",
     "pyzmq >= 23.0",
     "sh >= 1.14",


### PR DESCRIPTION
NumPy 2 has been [released last week](https://github.com/numpy/numpy/releases/tag/v2.0.0). It has several breaking changes.

Currently pytriton is not compatible with NumPy 2. If it is installed, all request input is garbled. It should be explicitly disallowed until it is properly supported.