### PR TITLE
PA Migration: Doc Updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2022-2023, NVIDIA CORPORATION. All rights reserved.
+Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,7 +197,7 @@ We introduced new alpha feature to PyTriton that allows to stream partial respon
 
 ### Profiling model
 
-The [Perf Analyzer](https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/README.md) can be
+The [Perf Analyzer](https://github.com/triton-inference-server/perf_analyzer/blob/main/README.md) can be
 used to profile models served through PyTriton. We have prepared an example of
 using the Perf Analyzer to profile the BART PyTorch model. The example code can be found
 in [examples/perf_analyzer](../examples/perf_analyzer).

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,7 +43,7 @@ The list of example models deployments:
 
 ## Profiling models
 
-The [Perf Analyzer](https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/README.md) can be
+The [Perf Analyzer](https://github.com/triton-inference-server/perf_analyzer/blob/main/README.md) can be
 used to profile the models served through PyTriton. We have prepared an example of
 using Perf Analyzer to profile BART PyTorch. See the example code in
 the [GitHub repository](../examples/perf_analyzer).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/perf_analyzer/README.md
+++ b/examples/perf_analyzer/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/perf_analyzer/README.md
+++ b/examples/perf_analyzer/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 ## Overview
 
 The example presents profiling of HuggingFace BART model using [Perf
-Analyzer](https://github.com/triton-inference-server/client/blob/main/src/c++/perf_analyzer/README.md)
+Analyzer](https://github.com/triton-inference-server/perf_analyzer/blob/main/README.md)
 
 Example consists of following scripts:
 


### PR DESCRIPTION
Point docs to new PA repo.

Server changes: https://github.com/triton-inference-server/server/pull/7488
Client changes: https://github.com/triton-inference-server/client/pull/771
PA changes: https://github.com/triton-inference-server/perf_analyzer/pull/21
DALI changes: https://github.com/triton-inference-server/dali_backend/pull/254
MA changes: https://github.com/triton-inference-server/model_analyzer/pull/925
Tutorial changes: https://github.com/triton-inference-server/tutorials/pull/105