### PR TITLE
expose requested_output_names in Request

### DIFF
--- a/pytriton/proxy/data.py
+++ b/pytriton/proxy/data.py
@@ -993,6 +993,8 @@ class TensorStoreSerializerDeserializer(BaseRequestsResponsesSerializerDeseriali
             serialized_request = {"data": serialized_request, "parameters": request.parameters}
             if request.span is not None:
                 serialized_request["span"] = get_span_dict(request.span)
+            if request.requested_output_names is not None:
+                serialized_request["requested_output_names"] = request.requested_output_names
             requests_list.append(serialized_request)
 
         requests = {"requests": requests_list}
@@ -1015,6 +1017,8 @@ class TensorStoreSerializerDeserializer(BaseRequestsResponsesSerializerDeseriali
                 span_dict = request["span"]
                 span = start_span_from_remote(span_dict, "proxy_inference_callable")
                 kwargs["span"] = span
+            if "requested_output_names" in request:
+                kwargs["requested_output_names"] = request["requested_output_names"]
             request_data = {
                 input_name: self._tensor_store.get(tensor_id)
                 for input_name, tensor_id in request.get("data", {}).items()

--- a/pytriton/proxy/model.py
+++ b/pytriton/proxy/model.py
@@ -136,7 +136,12 @@ class TritonRequestsServer:
         kwargs = {}
         if span is not None:
             kwargs["span"] = span
-        return Request(data=request, parameters=json.loads(triton_request.parameters()), **kwargs)
+        return Request(
+            data=request,
+            parameters=json.loads(triton_request.parameters()),
+            requested_output_names=list(triton_request.requested_output_names()),
+            **kwargs,
+        )
 
     async def _send_requests(self, requests_id: bytes, triton_requests, spans=None) -> ConcurrentFuture:
         requests = triton_requests

--- a/pytriton/proxy/types.py
+++ b/pytriton/proxy/types.py
@@ -31,6 +31,8 @@ class Request:
     """Parameters for the request."""
     span: Optional[Any] = None
     """Telemetry span for request"""
+    requested_output_names: Optional[List[str]] = None
+    """Requested output names for the request."""
 
     def __getitem__(self, input_name: str) -> np.ndarray:
         """Get input data."""

--- a/tests/unit/test_model_proxy_communication.py
+++ b/tests/unit/test_model_proxy_communication.py
@@ -54,7 +54,7 @@ class InferenceRequest:
     def __init__(self, model_name, inputs, requested_output_names, parameters=None):
         self.model_name = model_name
         self._inputs = inputs
-        self.requested_output_names = requested_output_names
+        self._requested_output_names = requested_output_names
         self._parameters = parameters or {}
 
     def inputs(self):
@@ -65,6 +65,9 @@ class InferenceRequest:
 
     def get_response_sender(self):
         return None
+
+    def requested_output_names(self):
+        return self._requested_output_names
 
 
 def _error_infer_fn(*_, **__):


### PR DESCRIPTION
This lets the server know if the client did not require a given input so it can skip computing it.

Note: I have already signed the CLA, see #49 and #78.